### PR TITLE
Parameterise obj.type in check_objects query

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -343,8 +343,8 @@ class authcode extends \auth_oidc\loginflow\base {
         $sql = 'SELECT u.username
                   FROM {local_o365_objects} obj
                   JOIN {user} u ON u.id = obj.moodleid
-                 WHERE obj.objectid = ? and obj.type = "user"';
-        $params = [$oidcuniqid];
+                 WHERE obj.objectid = ? and obj.type = ?';
+        $params = [$oidcuniqid, "user"];
         $user = $DB->get_record_sql($sql, $params);
         return (!empty($user)) ? $user->username : $username;
     }


### PR DESCRIPTION
On postgres, the check_objects query resulted in a 'column "user" does not exist' error - parameterising the obj.type = "name" part of the query seems to have fixed this.
