### PR TITLE
lowercase UPN to match restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Moodle Plugins for Microsoft Services
-*including* **Office 365** *and other Microsoft services*
+# Office 365 and Azure Active Directory Plugins for Moodle
 
 ## OpenID Connect Authentication Plugin.
 
@@ -20,6 +19,10 @@ This repository is updated with stable releases. To follow active development, s
 For more documentation, visit https://docs.moodle.org/34/en/Office365
 
 For more information including support and instructions on how to contribute, please see: https://github.com/Microsoft/o365-moodle/blob/master/README.md
+
+## Issues and Contributing
+Please post issues for this plugin to: https://github.com/Microsoft/o365-moodle/issues/
+Pull requests for this plugin should be submitted against our main repository: https://github.com/Microsoft/o365-moodle 
 
 ## Copyright
 

--- a/classes/loginflow/base.php
+++ b/classes/loginflow/base.php
@@ -389,6 +389,7 @@ class base {
             if (empty($tomatch)) {
                 $tomatch = $idtoken->claim('sub');
             }
+            $tomatch= strtolower($tomatch);
             foreach ($restrictions as $restriction) {
                 $restriction = trim($restriction);
                 if ($restriction !== '') {


### PR DESCRIPTION
the UPN match should case insensitivity when check user restrictions, espcially the UPN suffix, for example, @github.com  should be same as @GitHub.com