### PR TITLE
Avoid crashing when evaluating a token with a missing user ID.

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -418,13 +418,20 @@ class authcode extends \auth_oidc\loginflow\base {
             // Already connected user.
 
             if (empty($tokenrec->userid)) {
-                // ERROR.
-                echo 'ERROR1';die();
-            }
-            $user = $DB->get_record('user', ['id' => $tokenrec->userid]);
-            if (empty($user)) {
-                // ERROR.
-                echo 'ERROR2';die();
+                // Existing token record, but missing the user ID.
+                $user = $DB->get_record('user', ['username' => $tokenrec->username]);
+                if (empty($user)) {
+                    throw new \moodle_exception('errorauthloginfailednouser', 'auth_oidc', null, null, '3');
+                }
+                $tokenrec->userid = $user->id;
+                $DB->update_record('auth_oidc_token', $tokenrec);
+
+            } else {
+                // Existing token with a user ID.
+                $user = $DB->get_record('user', ['id' => $tokenrec->userid]);
+                if (empty($user)) {
+                    throw new \moodle_exception('errorauthloginfailednouser', 'auth_oidc', null, null, '4');
+                }
             }
             $username = $user->username;
             $this->updatetoken($tokenrec->id, $authparams, $tokenparams);


### PR DESCRIPTION
After rolling out OIDC authentication, we found a sizeable number of our users were unable to sign in, despite having an existing Moodle user account and successful authentication attempts logged in Azure AD. 

It seems that in the course of normal operations, auth_oidc_token records are created with a default userid of 0 and are only given this information at the last possible moment, in a post-authentication hook. If for whatever reason this step isn't reached, and there is a token for a user on file with this default, every subsequent login the user would receive a crash with the text "ERROR1". This patch adds a check to update the userid field if there is a user with a matching username, and replaces the crash with a relevant exception.