### PR TITLE
Start authentication flow if user guest Start authentication flow if user guest

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -106,7 +106,7 @@ class authcode extends \auth_oidc\loginflow\base {
             // Response from OP.
             $this->handleauthresponse($requestparams);
         } else {
-            if (isloggedin() && empty($justauth) && empty($promptaconsent)) {
+            if (isloggedin() && !isguestuser() && empty($justauth) && empty($promptaconsent)) {
                 if (isset($SESSION->wantsurl) and (strpos($SESSION->wantsurl, $CFG->wwwroot) === 0)) {
                     $urltogo = $SESSION->wantsurl;
                     unset($SESSION->wantsurl);

--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -107,6 +107,8 @@ class authcode extends \auth_oidc\loginflow\base {
             $this->handleauthresponse($requestparams);
         } else {
             if (isloggedin() && !isguestuser() && empty($justauth) && empty($promptaconsent)) {
+                global $USER;
+                if($USER->id )
                 if (isset($SESSION->wantsurl) and (strpos($SESSION->wantsurl, $CFG->wwwroot) === 0)) {
                     $urltogo = $SESSION->wantsurl;
                     unset($SESSION->wantsurl);
@@ -115,6 +117,10 @@ class authcode extends \auth_oidc\loginflow\base {
                 }
                 redirect($urltogo);
                 die();
+            }
+            //Handle Guest account session termination
+            if(isguestuser()){
+                require_logout();
             }
             // Initial login request.
             $stateparams = ['forceflow' => 'authcode'];


### PR DESCRIPTION
When a user is already authenticated as guest and try to login, authentication flow is skipped and the user stays connected as guest.
Added skip condition to check that connected user is not guest and logout guest user before authentication flow starts.