### PR TITLE
Use $CFG->lang instead of hardcoded "en"

### DIFF
--- a/classes/loginflow/base.php
+++ b/classes/loginflow/base.php
@@ -89,7 +89,7 @@ class base {
      * @return mixed array with no magic quotes or false on error
      */
     public function get_userinfo($username) {
-        global $DB;
+        global$CFG, $DB;
 
         $tokenrec = $DB->get_record('auth_oidc_token', ['username' => $username]);
         if (empty($tokenrec)) {
@@ -99,7 +99,7 @@ class base {
         $idtoken = \auth_oidc\jwt::instance_from_encoded($tokenrec->idtoken);
 
         $userinfo = [
-            'lang' => 'en',
+            'lang' => $CFG->lang, 
             'idnumber' => $username,
         ];
 


### PR DESCRIPTION
User creation should use global config instead of hardcode "en" language.