### PR TITLE
Fixing delete_records_select call

### DIFF
--- a/classes/task/cleanup_oidc_state_and_token.php
+++ b/classes/task/cleanup_oidc_state_and_token.php
@@ -44,7 +44,7 @@ class cleanup_oidc_state_and_token extends scheduled_task {
         global $DB;
 
         // Clean up oidc state.
-        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', strtotime('-5 min'));
+        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', [strtotime('-5 min')]);
 
         // Clean up invalid oidc token.
         $DB->delete_records('auth_oidc_token', ['userid' => 0]);


### PR DESCRIPTION
`delete_records_select` take an array as third parameter.
Passing an int crashed the task with following error : 
```php
!! Exception : Argument 3 passed to mysqli_native_moodle_database::delete_records_select() must be of the type array or null, int given, called in [dirroot]/auth/oidc/classes/task/cleanup_oidc_state_and_token.php on line 47 !!!
```