### PR TITLE
made tokenresource optional

### DIFF
--- a/classes/oidcclient.php
+++ b/classes/oidcclient.php
@@ -68,21 +68,7 @@ class oidcclient {
         $this->clientid = $id;
         $this->clientsecret = $secret;
         $this->redirecturi = $redirecturi;
-        if (!empty($tokenresource)) {
-            $this->tokenresource = $tokenresource;
-        } else {
-            $o365installed = $DB->get_record('config_plugins', ['plugin' => 'local_o365', 'name' => 'version']);
-            if (!empty($o365installed)) {
-                if (\local_o365\rest\o365api::use_chinese_api() === true) {
-                    $this->tokenresource = 'https://microsoftgraph.chinacloudapi.cn';
-                } else {
-                    $this->tokenresource = 'https://graph.microsoft.com';
-                }
-            } else {
-                $this->tokenresource = 'https://graph.microsoft.com';
-            }
-
-        }
+        $this->tokenresource = (!empty($tokenresource)) ? $tokenresource : null;
         $this->scope = (!empty($scope)) ? $scope : 'openid profile email';
     }
 
@@ -165,10 +151,12 @@ class oidcclient {
             'scope' =>  $this->scope,
             'nonce' => $nonce,
             'response_mode' => 'form_post',
-            'resource' => $this->tokenresource,
             'state' => $this->getnewstate($nonce, $stateparams),
             'redirect_uri' => $this->redirecturi
         ];
+        if (!is_null($this->tokenresource)) {
+            $params['resource'] = $this->tokenresource;
+        }
         if ($promptlogin === true) {
             $params['prompt'] = 'login';
         }

--- a/settings.php
+++ b/settings.php
@@ -48,7 +48,7 @@ $settings->add(new admin_setting_configtext('auth_oidc/tokenendpoint', $configke
 
 $configkey = new lang_string('cfg_oidcresource_key', 'auth_oidc');
 $configdesc = new lang_string('cfg_oidcresource_desc', 'auth_oidc');
-$configdefault = 'https://graph.microsoft.com';
+$configdefault = 'null';
 $settings->add(new admin_setting_configtext('auth_oidc/oidcresource', $configkey, $configdesc, $configdefault, PARAM_TEXT));
 
 $configkey = new lang_string('cfg_oidcscope_key', 'auth_oidc');


### PR DESCRIPTION
It addresses the [issue#1664](https://github.com/microsoft/o365-moodle/issues/1664)

`tokenresource` or `resource` is made optional, it'll allow an IdP to authenticate without authorizing(if not needed) any API