### PR TITLE
Argument 3 passed to delete_records_select() must be of the type array or null

### DIFF
--- a/classes/task/cleanup_oidc_state_and_token.php
+++ b/classes/task/cleanup_oidc_state_and_token.php
@@ -44,7 +44,7 @@ class cleanup_oidc_state_and_token extends scheduled_task {
         global $DB;
 
         // Clean up oidc state.
-        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', strtotime('-5 min'));
+        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', array(strtotime('-5 min')));
 
         // Clean up invalid oidc token.
         $DB->delete_records('auth_oidc_token', ['userid' => 0]);


### PR DESCRIPTION
The scheduled task was failing with the following error:
Argument 3 passed to pgsql_native_moodle_database::delete_records_select() must be of the type array or null, integer given, called in /auth/oidc/classes/task/cleanup_oidc_state_and_token.php on line 47

Put strtotime function inside array() to fix this