### PR TITLE
Delete local_o365_objects entry when deleting tokens

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -203,7 +203,7 @@ function auth_oidc_get_tokens_with_mismatched_usernames() {
  * @param int $tokenid
  * @throws dml_exception
  */
-function auth_oidc_delete_token(int $tokenid) {
+function auth_oidc_delete_token(int $tokenid): void {
     global $DB;
 
     if (auth_oidc_is_local_365_installed()) {

--- a/lib.php
+++ b/lib.php
@@ -211,7 +211,7 @@ function auth_oidc_delete_token(int $tokenid): void {
                   FROM {local_o365_objects} obj
                   JOIN {auth_oidc_token} tok ON obj.o365name = tok.username
                   JOIN {user} u ON obj.moodleid = u.id
-                 WHERE type = :type AND tok.id = :tokenid';
+                 WHERE obj.type = :type AND tok.id = :tokenid';
         if ($objectrecord = $DB->get_record_sql($sql, ['type' => 'user', 'tokenid' => $tokenid], IGNORE_MULTIPLE)) {
             // Delete record from local_o365_objects.
             $DB->delete_records('local_o365_objects', ['id' => $objectrecord->id]);

--- a/lib.php
+++ b/lib.php
@@ -201,6 +201,7 @@ function auth_oidc_get_tokens_with_mismatched_usernames() {
  * Delete the auth_oidc token with the ID.
  *
  * @param int $tokenid
+ * @throws dml_exception
  */
 function auth_oidc_delete_token(int $tokenid) {
     global $DB;

--- a/lib.php
+++ b/lib.php
@@ -213,7 +213,7 @@ function auth_oidc_delete_token(int $tokenid) {
                  WHERE type = :type AND tok.id = :tokenid';
         if ($objectrecord = $DB->get_record_sql($sql, ['type' => 'user', 'tokenid' => $tokenid], IGNORE_MULTIPLE)) {
             // Delete record from local_o365_objects.
-            $DB->get_records('local_o365_objects', ['id' => $objectrecord->id]);
+            $DB->delete_records('local_o365_objects', ['id' => $objectrecord->id]);
 
             // Delete record from local_o365_token.
             $DB->delete_records('local_o365_token', ['user_id' => $objectrecord->userid]);


### PR DESCRIPTION
Originally, a call to $DB->get_records() was made instead of $DB->delete_records(), as the comment above it suggests.